### PR TITLE
feat: add 前端编码规范工程化标准脚手架 ise-fe-lint fix 指令，支持项目一键修复

### DIFF
--- a/packages/ise-fe-lint/__test__/cli.test.js
+++ b/packages/ise-fe-lint/__test__/cli.test.js
@@ -10,7 +10,6 @@ const cli = (args, options) => {
       return result;
     })
     .catch((error) => {
-      console.error('执行命令出错:', error);
       console.error('错误时的stderr:', error.stderr);
       throw error;
     });
@@ -37,5 +36,27 @@ describe(`'exec' command`, () => {
   test(`'exec commitlint' should work as expected`, async () => {
     const { stdout } = await cli(['exec', 'commitlint', '--version']);
     expect(stdout).toMatch(semverRegex);
+  });
+});
+
+describe(`'fix' command`, () => {
+  const dir = path.resolve(__dirname, './fixtures/autofix');
+  const outputFilePath = path.resolve(dir, './temp/temp.js');
+  const errorFileContent = fs.readFileSync(path.resolve(dir, './semi-error.js'), 'utf8');
+  const expectedFileContent = fs.readFileSync(path.resolve(dir, './semi-expected.js'), 'utf8');
+
+  beforeEach(() => {
+    fs.outputFileSync(outputFilePath, errorFileContent, 'utf8');
+  });
+
+  test('should autofix problematic code', async () => {
+    await cli(['fix'], {
+      cwd: path.dirname(`${dir}/result`),
+    });
+    expect(fs.readFileSync(outputFilePath, 'utf8')).toEqual(expectedFileContent);
+  });
+
+  afterEach(() => {
+    fs.removeSync(`${dir}/temp`);
   });
 });

--- a/packages/ise-fe-lint/src/cli.ts
+++ b/packages/ise-fe-lint/src/cli.ts
@@ -92,6 +92,28 @@ const initProgram = () => {
       runErrors.forEach((e) => console.log(e));
     });
 
+  program
+    .command('fix')
+    .description('一键修复：自动修复项目的代码规范扫描问题')
+    .option('-i, --include <dirpath>', '指定要进行修复扫描的目录')
+    .option('--no-ignore', '忽略 eslint 的 ignore 配置文件和 ignore 规则')
+    .action(async (cmd) => {
+      await installDepsIfThereNo();
+
+      const checking = ora();
+      checking.start(`执行 ${PKG_NAME} 代码修复`);
+
+      const { results } = await scan({
+        cwd,
+        fix: true,
+        include: cmd.include || cwd,
+        ignore: cmd.ignore, // 对应 --no-ignore
+      });
+
+      checking.succeed();
+      if (results.length > 0) printReport(results, true);
+    });
+
   // 解析命令行参数
   program.parse(process.argv);
 };

--- a/packages/ise-fe-lint/src/lints/eslint/formatESLintResults.ts
+++ b/packages/ise-fe-lint/src/lints/eslint/formatESLintResults.ts
@@ -33,7 +33,7 @@ export function formatESLintResults(
               line,
               column,
               rule: ruleId,
-              url: rulesMeta[ruleId]?.docs?.url || '',
+              url: `https://github.com/eslint/eslint/blob/v8.7.0/docs/rules/${ruleId}.md`,
               message: message.replace(/([^ ])\.$/u, '$1'),
               errored: fatal || severity === 2,
             };


### PR DESCRIPTION
一键修复需要借助一键扫描的Linter提供的 fix 能力，在使用 fix 时一定要注意指定好要修复的目录范围，否则会非常慢，下面是对比（实际比图示还要慢很多）：

- 没有指定目录范围
![20250416-105243](https://github.com/user-attachments/assets/cb6d6c7b-8477-4398-9756-6386bdf7d311)

- 指定目录范围
![20250416-105454](https://github.com/user-attachments/assets/d6cd9f27-fd41-4bcf-8729-d5763abfbe21)

注意：
- 如果 VSCode 已经开启了 prettier 插件，需要先禁用，否则保存不合规范的代码就会自动格式化
- fix 只会修复不合规范且可以自动修复的代码，对于那些无法自动修复的代码还是需要手动修复处理